### PR TITLE
Fix depricated method of creating a root node.

### DIFF
--- a/Trivago/Jade/Application/Framework/JadeBundle/DependencyInjection/Configuration.php
+++ b/Trivago/Jade/Application/Framework/JadeBundle/DependencyInjection/Configuration.php
@@ -38,9 +38,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('trivago_jade');
-        $rootNode
+        $treeBuilder = new TreeBuilder('trivago_jade');
+        $treeBuilder->getRootNode()
             ->validate()
                 ->ifTrue(function($values) {
                     $values['security']['enabled'] && (!$values['security']['default_manipulate_role'] || $values['security']['default_read_role']);


### PR DESCRIPTION
One additional fix to the migration to 4.2, its easy to get this in before its released.

As of Symfony 4.2, creating a config tree without a root node, is deprecated.

See https://github.com/symfony/symfony/pull/27476.